### PR TITLE
Add MySQL server and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 
 # Logs
 *.log
+*.deb

--- a/README.md
+++ b/README.md
@@ -244,3 +244,18 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 ## Contact
 
 For questions and support, please open an issue on GitHub.
+
+### SQL Server
+
+A lightweight MySQL server is included via `docker-compose`. Start the services with:
+```bash
+docker-compose up
+```
+This launches the AGI system container alongside a MySQL 8.0 instance. Alternatively, you can start a local server directly:
+```bash
+./tools/start_mysql.sh
+```
+After the server is running you can test the connection using:
+```bash
+python python/db_test.py
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,4 +7,14 @@ services:
       - ./src:/app/src
       - ./build:/app/build
     tty: true
-    stdin_open: true 
+    stdin_open: true
+    depends_on:
+      - mysql
+
+  mysql:
+    image: mysql:8.0
+    restart: always
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+    ports:
+      - '3306:3306'

--- a/python/db_test.py
+++ b/python/db_test.py
@@ -1,0 +1,18 @@
+import os
+import pymysql
+
+
+def main():
+    host = os.environ.get('MYSQL_HOST', '127.0.0.1')
+    user = os.environ.get('MYSQL_USER', 'root')
+    password = os.environ.get('MYSQL_PASSWORD', '')
+    conn = pymysql.connect(host=host, user=user, password=password)
+    with conn.cursor() as cur:
+        cur.execute('SELECT 1 + 1')
+        result = cur.fetchone()[0]
+        print('DB result:', result)
+    conn.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 torch
 gymnasium
+pymysql

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -1,0 +1,45 @@
+import os
+import time
+import subprocess
+import pymysql
+
+DATA_DIR = '/tmp/mysql-data-test'
+
+
+def ensure_server():
+    if not os.path.isdir(os.path.join(DATA_DIR, 'mysql')):
+        subprocess.run(['mysqld', '--initialize-insecure', f'--datadir={DATA_DIR}', '--basedir=/usr'], check=True)
+    proc = subprocess.Popen([
+        'mysqld',
+        f'--datadir={DATA_DIR}',
+        '--user=root',
+        '--bind-address=127.0.0.1',
+        '--skip-networking=0',
+        '--socket=/tmp/mysql.sock'
+    ])
+    # wait for server to be ready
+    for _ in range(10):
+        try:
+            conn = pymysql.connect(host='127.0.0.1', user='root', connect_timeout=1)
+            conn.close()
+            return proc
+        except Exception:
+            time.sleep(1)
+    raise RuntimeError('MySQL server failed to start')
+
+
+def main():
+    proc = ensure_server()
+    conn = pymysql.connect(host='127.0.0.1', user='root')
+    cur = conn.cursor()
+    cur.execute('SELECT 1 + 1')
+    result = cur.fetchone()[0]
+    assert result == 2
+    print('SQL test passed.')
+    conn.close()
+    proc.terminate()
+    proc.wait(timeout=10)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/start_mysql.sh
+++ b/tools/start_mysql.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Initialize and launch a local MySQL server for testing
+set -e
+DATA_DIR=${MYSQL_DATA_DIR:-/tmp/mysql-data}
+if [ ! -d "$DATA_DIR/mysql" ]; then
+    mysqld --initialize-insecure --datadir="$DATA_DIR" --basedir=/usr
+fi
+mysqld --datadir="$DATA_DIR" --user=root --bind-address=127.0.0.1 --skip-networking=0 --socket=/tmp/mysql.sock &
+MYSQL_PID=$!
+echo $MYSQL_PID > "$DATA_DIR/mysqld.pid"
+# Wait briefly for server startup
+sleep 5
+

--- a/tools/stop_mysql.sh
+++ b/tools/stop_mysql.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Stop MySQL server started with start_mysql.sh
+set -e
+DATA_DIR=${MYSQL_DATA_DIR:-/tmp/mysql-data}
+if [ -f "$DATA_DIR/mysqld.pid" ]; then
+    kill $(cat "$DATA_DIR/mysqld.pid")
+    rm -f "$DATA_DIR/mysqld.pid"
+fi
+


### PR DESCRIPTION
## Summary
- add docker compose mysql service
- add optional start/stop scripts for a local mysql server
- include sample DB connection script
- add a python test that starts mysqld and checks a query
- document new SQL server usage
- include pymysql in requirements
- ignore `.deb` packages

## Testing
- `make clean && make all`
- `python3 tests/test_sql.py`
- `./build/agi_system`


------
https://chatgpt.com/codex/tasks/task_e_684dcd9fce98832e979c1dbb01617ee3